### PR TITLE
adding API_HOST and API_PORT to be read from environment or default a…

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   tileLayer: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
-  host: 'http://localhost',
-  port: '3000',
+  host: process.env.API_HOST || 'http://localhost', 
+  port: process.env.API_PORT || '3000', 
   maxTaskNumber: 100,
   overpassEndpoint: 'https://overpass-api.de/api/interpreter'
 };


### PR DESCRIPTION
Added API_HOST and API_PORT for reading the configration from environment, fallback option will be "http://localhost" port will be 3000.

Snippet:

```js
'use strict';

module.exports = {
  tileLayer: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
  host: process.env.API_HOST || 'http://localhost', # Updated this line
  port: process.env.API_PORT || '3000',             # Updated this line
  maxTaskNumber: 100,
  overpassEndpoint: 'https://overpass-api.de/api/interpreter'
};
```